### PR TITLE
APPS-10528: NACK statistics

### DIFF
--- a/pjmedia/build/Makefile
+++ b/pjmedia/build/Makefile
@@ -65,7 +65,7 @@ export PJMEDIA_OBJS += $(OS_OBJS) $(M_OBJS) $(CC_OBJS) $(HOST_OBJS) \
 			echo_port.o echo_suppress.o echo_webrtc.o echo_webrtc_aec3.o \
 			endpoint.o errno.o event.o format.o ffmpeg_util.o \
 			g711.o jbuf.o master_port.o mem_capture.o mem_player.o \
-			null_port.o plc_common.o port.o splitcomb.o \
+			nack_buffer.o null_port.o plc_common.o port.o splitcomb.o \
 			resample_resample.o resample_libsamplerate.o resample_speex.o \
 			resample_port.o rtcp.o rtcp_xr.o rtcp_fb.o rtp.o \
 			sdp.o sdp_cmp.o sdp_neg.o session.o silencedet.o \
@@ -157,6 +157,7 @@ export PJMEDIA_TEST_OBJS += codec_vectors.o jbuf_test.o main.o mips_test.o \
 			    vid_codec_test.o vid_dev_test.o vid_port_test.o \
 			    rtp_test.o test.o
 export PJMEDIA_TEST_OBJS += sdp_neg_test.o 
+export PJMEDIA_TEST_OBJS += nack_buffer_test.o
 export PJMEDIA_TEST_CFLAGS += $(_CFLAGS)
 export PJMEDIA_TEST_CXXFLAGS += $(_CXXFLAGS)
 export PJMEDIA_TEST_LDFLAGS += $(PJMEDIA_CODEC_LDLIB) \

--- a/pjmedia/include/pjmedia/jbuf.h
+++ b/pjmedia/include/pjmedia/jbuf.h
@@ -285,6 +285,7 @@ PJ_DECL(void) pjmedia_jbuf_put_frame( pjmedia_jbuf *jb,
  *                      offset.
  * @param frame_seq     The frame sequence number.
  * @param discarded     Flag whether the frame is discarded by jitter buffer.
+ * @param packet_seq    Sequnce number of RTP packet with given frame. 
  */
 PJ_DECL(void) pjmedia_jbuf_put_frame2( pjmedia_jbuf *jb, 
                                        const void *frame, 
@@ -313,6 +314,7 @@ PJ_DECL(void) pjmedia_jbuf_put_frame2( pjmedia_jbuf *jb,
  * @param frame_seq     The frame sequence number.
  * @param frame_ts      The frame timestamp.
  * @param discarded     Flag whether the frame is discarded by jitter buffer.
+ * @param packet_seq    Sequnce number of RTP packet with given frame. 
  */
 PJ_DECL(void) pjmedia_jbuf_put_frame3( pjmedia_jbuf *jb, 
                                        const void *frame, 
@@ -366,6 +368,7 @@ PJ_DECL(void) pjmedia_jbuf_get_frame( pjmedia_jbuf *jb,
  *                      exactly start and end at the octet boundary, so this
  *                      field may be used for specifying start & end bit
  *                      offset.
+ *  @param packet_seq   Sequnce number of RTP packet with given frame. 
  */
 PJ_DECL(void) pjmedia_jbuf_get_frame2(pjmedia_jbuf *jb, 
                                       void *frame, 
@@ -392,6 +395,7 @@ PJ_DECL(void) pjmedia_jbuf_get_frame2(pjmedia_jbuf *jb,
  *                      offset.
  * @param ts            Frame timestamp.
  * @param seq           Frame sequence number.
+ * @param packet_seq    Sequnce number of RTP packet with given frame. 
  */
 PJ_DECL(void) pjmedia_jbuf_get_frame3(pjmedia_jbuf *jb, 
                                       void *frame, 

--- a/pjmedia/include/pjmedia/jbuf.h
+++ b/pjmedia/include/pjmedia/jbuf.h
@@ -291,7 +291,8 @@ PJ_DECL(void) pjmedia_jbuf_put_frame2( pjmedia_jbuf *jb,
                                        pj_size_t size, 
                                        pj_uint32_t bit_info,
                                        int frame_seq,
-                                       pj_bool_t *discarded);
+                                       pj_bool_t *discarded,
+                                       pj_uint16_t packet_seq);
 
 /**
  * Put a frame to the jitter buffer. If the frame can be accepted (based
@@ -319,7 +320,8 @@ PJ_DECL(void) pjmedia_jbuf_put_frame3( pjmedia_jbuf *jb,
                                        pj_uint32_t bit_info,
                                        int frame_seq,
                                        pj_uint32_t frame_ts,
-                                       pj_bool_t *discarded);
+                                       pj_bool_t *discarded,
+                                       pj_uint16_t packet_seq);
 /**
  * Get a frame from the jitter buffer. The jitter buffer will return the
  * oldest frame from it's buffer, when it is available.
@@ -369,7 +371,8 @@ PJ_DECL(void) pjmedia_jbuf_get_frame2(pjmedia_jbuf *jb,
                                       void *frame, 
                                       pj_size_t *size, 
                                       char *p_frm_type,
-                                      pj_uint32_t *bit_info);
+                                      pj_uint32_t *bit_info,
+                                      pj_uint16_t *packet_seq);
 
 
 /**
@@ -396,7 +399,8 @@ PJ_DECL(void) pjmedia_jbuf_get_frame3(pjmedia_jbuf *jb,
                                       char *p_frm_type,
                                       pj_uint32_t *bit_info,
                                       pj_uint32_t *ts,
-                                      int *seq);
+                                      int *seq,
+                                      pj_uint16_t *packet_seq);
 
 
 /**

--- a/pjmedia/include/pjmedia/nack_buffer.h
+++ b/pjmedia/include/pjmedia/nack_buffer.h
@@ -21,7 +21,7 @@ pjmedia_nack_buffer_create(pj_pool_t *pool,
                           unsigned size,
                           pjmedia_nack_buffer **buffer);
 
-PJ_DECL(void)
+PJ_DECL(pj_status_t)
 pjmedia_nack_buffer_reset(pjmedia_nack_buffer *buffer);
 
 PJ_DECL(pj_status_t)

--- a/pjmedia/include/pjmedia/nack_buffer.h
+++ b/pjmedia/include/pjmedia/nack_buffer.h
@@ -1,0 +1,36 @@
+#ifndef __PJMEDIA_NACK_BUFFER_H__
+#define __PJMEDIA_NACK_BUFFER_H__
+
+/**
+ * @file nack_buffer.h
+ * @brief Ring buffer for packet ids sent in NACK message.
+ */
+
+#include <pjmedia/rtcp_fb.h>
+#include <pjmedia/types.h>
+
+PJ_BEGIN_DECL
+
+/**
+ * Opaque declaration for nack buffer.
+ */
+typedef struct pjmedia_nack_buffer pjmedia_nack_buffer;
+
+PJ_DECL(pj_status_t)
+pjmedia_nack_buffer_create(pj_pool_t *pool,
+                          unsigned size,
+                          pjmedia_nack_buffer **buffer);
+
+PJ_DECL(pj_status_t)
+pjmedia_nack_buffer_push(pjmedia_nack_buffer *buffer,
+                         pjmedia_rtcp_fb_nack nack);
+
+PJ_DECL(pj_bool_t)
+pjmedia_nack_buffer_frame_dequeued(pjmedia_nack_buffer *buffer,
+                                   uint16_t sequence_num);
+
+unsigned pjmedia_nack_buffer_len(pjmedia_nack_buffer *buffer);
+
+PJ_END_DECL
+
+#endif /* __PJMEDIA_NACK_BUFFER_H__ */

--- a/pjmedia/include/pjmedia/nack_buffer.h
+++ b/pjmedia/include/pjmedia/nack_buffer.h
@@ -21,6 +21,9 @@ pjmedia_nack_buffer_create(pj_pool_t *pool,
                           unsigned size,
                           pjmedia_nack_buffer **buffer);
 
+PJ_DECL(void)
+pjmedia_nack_buffer_reset(pjmedia_nack_buffer *buffer);
+
 PJ_DECL(pj_status_t)
 pjmedia_nack_buffer_push(pjmedia_nack_buffer *buffer,
                          pjmedia_rtcp_fb_nack nack);

--- a/pjmedia/include/pjmedia/rtcp.h
+++ b/pjmedia/include/pjmedia/rtcp.h
@@ -178,25 +178,25 @@ typedef struct pjmedia_rtcp_ntp_rec
  */
 typedef struct pjmedia_rtcp_stream_stat
 {
-    pj_time_val     update;     /**< Time of last update.                   */
-    unsigned        update_cnt; /**< Number of updates (to calculate avg)   */
-    pj_uint32_t     pkt;        /**< Total number of packets                */
-    pj_uint32_t     bytes;      /**< Total number of payload/bytes          */
-    unsigned        discard;    /**< Total number of discarded packets.     */
-    unsigned        loss;       /**< Total number of packets lost           */
-    unsigned        reorder;    /**< Total number of out of order packets   */
-    unsigned        dup;        /**< Total number of duplicates packets     */
-    unsigned        nack_cnt;   /**< Total number of NACK packets           */
+    pj_time_val     update;     /**< Time of last update.                           */
+    unsigned        update_cnt; /**< Number of updates (to calculate avg)           */
+    pj_uint32_t     pkt;        /**< Total number of packets                        */
+    pj_uint32_t     bytes;      /**< Total number of payload/bytes                  */
+    unsigned        discard;    /**< Total number of discarded packets.             */
+    unsigned        loss;       /**< Total number of packets lost                   */
+    unsigned        reorder;    /**< Total number of out of order packets           */
+    unsigned        dup;        /**< Total number of duplicates packets             */
+    unsigned        nack_cnt;   /**< Total number of packets requested using NACK   */
     unsigned        useful_nack_cnt;/**< Total number of played NACK packets*/
 
-    pj_math_stat    loss_period;/**< Loss period statistics (in usec)       */
+    pj_math_stat    loss_period;/**< Loss period statistics (in usec)               */
 
     struct {
-        unsigned    burst:1;    /**< Burst/sequential packet lost detected  */
-        unsigned    random:1;   /**< Random packet lost detected.           */
-    } loss_type;                /**< Types of loss detected.                */
+        unsigned    burst:1;    /**< Burst/sequential packet lost detected          */
+        unsigned    random:1;   /**< Random packet lost detected.                   */  
+    } loss_type;                /**< Types of loss detected.                        */
 
-    pj_math_stat    jitter;     /**< Jitter statistics (in usec)            */
+    pj_math_stat    jitter;     /**< Jitter statistics (in usec)                    */
 
 } pjmedia_rtcp_stream_stat;
 

--- a/pjmedia/include/pjmedia/rtcp.h
+++ b/pjmedia/include/pjmedia/rtcp.h
@@ -187,6 +187,7 @@ typedef struct pjmedia_rtcp_stream_stat
     unsigned        reorder;    /**< Total number of out of order packets   */
     unsigned        dup;        /**< Total number of duplicates packets     */
     unsigned        nack_cnt;   /**< Total number of NACK packets           */
+    unsigned        useful_nack_cnt;/**< Total number of played NACK packets*/
 
     pj_math_stat    loss_period;/**< Loss period statistics (in usec)       */
 

--- a/pjmedia/include/pjmedia/rtcp.h
+++ b/pjmedia/include/pjmedia/rtcp.h
@@ -186,6 +186,7 @@ typedef struct pjmedia_rtcp_stream_stat
     unsigned        loss;       /**< Total number of packets lost           */
     unsigned        reorder;    /**< Total number of out of order packets   */
     unsigned        dup;        /**< Total number of duplicates packets     */
+    unsigned        nack_cnt;   /**< Total number of NACK packets           */
 
     pj_math_stat    loss_period;/**< Loss period statistics (in usec)       */
 

--- a/pjmedia/src/pjmedia/nack_buffer.c
+++ b/pjmedia/src/pjmedia/nack_buffer.c
@@ -45,12 +45,18 @@ pjmedia_nack_buffer_create(pj_pool_t *pool,
     PJ_ASSERT_RETURN(nack_buffer->packets != NULL, PJ_ENOMEM);
 
     nack_buffer->size = size;
-    nack_buffer->count = 0;
-    nack_buffer->head = 0;
-    nack_buffer->tail = 0;
+    pjmedia_nack_buffer_reset(nack_buffer);
 
     *buffer = nack_buffer;
     return PJ_SUCCESS;
+}
+
+PJ_DEF(void)
+pjmedia_nack_buffer_reset(pjmedia_nack_buffer *buffer) {
+    PJ_LOG(3, (THIS_FILE, "Nack buffer restarted."));
+    buffer->count = 0;
+    buffer->head = 0;
+    buffer->tail = 0;
 }
 
 PJ_DEF(pj_status_t)

--- a/pjmedia/src/pjmedia/nack_buffer.c
+++ b/pjmedia/src/pjmedia/nack_buffer.c
@@ -66,7 +66,7 @@ pjmedia_nack_buffer_push(pjmedia_nack_buffer *buffer,
         buffer->tail = (buffer->tail + 1) % buffer->size;
     }
 
-    PJ_LOG(3, (THIS_FILE, "debug Nacked packet with pid: %u, blp: %u was added!", nack->pid, nack->blp));
+    PJ_LOG(3, (THIS_FILE, "debug Nacked packet with pid: %u, blp: %u was added!", nack.pid, nack.blp));
     PJ_LOG(3, (THIS_FILE, "debug Buffer length: %u.", buffer->count));
 
     buffer->packets[buffer->head] = nack;

--- a/pjmedia/src/pjmedia/nack_buffer.c
+++ b/pjmedia/src/pjmedia/nack_buffer.c
@@ -1,0 +1,122 @@
+#include <pjmedia/nack_buffer.h>
+#include <pjmedia/rtcp_fb.h>
+#include <pjmedia/types.h>
+#include <pj/pool.h>
+#include <pj/errno.h>
+#include <pj/assert.h>
+#include <pj/log.h>
+
+#define THIS_FILE   "nack_buffer.c"
+
+struct pjmedia_nack_buffer {
+    unsigned head;
+    unsigned tail;
+    unsigned count;
+    unsigned size;
+    pjmedia_rtcp_fb_nack *packets;
+};
+
+static pj_bool_t blp_contains(pjmedia_rtcp_fb_nack *packet, uint16_t sequence_num) {
+    PJ_ASSERT_RETURN(sequence_num > packet->pid, PJ_FALSE);
+    uint16_t diff = sequence_num - packet->pid;
+
+    if (diff <= 16 && (packet->blp & (1 << diff - 1))) {
+        return PJ_TRUE;
+    } else {
+        return PJ_FALSE;
+    }    
+}
+
+PJ_DEF(pj_status_t)
+pjmedia_nack_buffer_create(pj_pool_t *pool,
+                           unsigned size,
+                           pjmedia_nack_buffer **buffer) {
+
+    pjmedia_nack_buffer *nack_buffer = PJ_POOL_ZALLOC_T(pool, pjmedia_nack_buffer);
+    PJ_ASSERT_RETURN(nack_buffer != NULL, PJ_ENOMEM);
+
+    nack_buffer->packets = pj_pool_alloc(pool, size * sizeof(pjmedia_rtcp_fb_nack));
+    PJ_ASSERT_RETURN(nack_buffer->packets != NULL, PJ_ENOMEM);
+
+    nack_buffer->size = size;
+    nack_buffer->count = 0;
+    nack_buffer->head = 0;
+    nack_buffer->tail = 0;
+
+    *buffer = nack_buffer;
+    return PJ_SUCCESS;
+}
+
+PJ_DEF(pj_status_t)
+pjmedia_nack_buffer_push(pjmedia_nack_buffer *buffer,
+                         pjmedia_rtcp_fb_nack nack) {
+
+    PJ_ASSERT_RETURN(buffer, PJ_EINVAL);
+    
+    if (buffer->count < buffer->size) {
+        buffer->count++;
+    } else {
+        PJ_LOG(3, (THIS_FILE, "Buffer is full, overwriting oldest packet."));
+        buffer->tail = (buffer->tail + 1) % buffer->size;
+    }
+
+    buffer->packets[buffer->head] = nack;
+    buffer->head = (buffer->head + 1) % buffer->size;
+
+    return PJ_SUCCESS;
+}
+
+// Function to check if a packet with the given sequence number was NACKed and remove older packets.
+PJ_DECL(pj_bool_t)
+pjmedia_nack_buffer_frame_dequeued(pjmedia_nack_buffer *buffer,
+                                   uint16_t sequence_num) {
+    if (buffer->count == 0) {
+        return PJ_FALSE; 
+    }
+    
+    int lower = 0;
+    int upper = buffer->count - 1;
+    int index = -1;
+
+    // Perform a binary search for the packet with the closest PID <= the sequence number
+    while (lower <= upper) {
+        int middle = (lower + upper) / 2;
+        uint16_t pid = buffer->packets[(buffer->tail + middle) % buffer->size].pid;
+
+        if (pid <= sequence_num) {
+            index = middle;
+            lower = middle + 1;
+        } else {
+            upper = middle - 1;
+        }
+    }
+
+    PJ_LOG(3,(THIS_FILE, "Packet %u. Index: %i", sequence_num, index));
+
+    if (index == -1) {
+        return PJ_FALSE;
+    }
+
+    pjmedia_rtcp_fb_nack *packet = &buffer->packets[(buffer->tail + index) % buffer->size];
+
+    PJ_LOG(3,(THIS_FILE, "Found packet pid %u.", packet->pid));
+
+    if (packet->pid == sequence_num || blp_contains(packet, sequence_num)) {
+        PJ_LOG(3,(THIS_FILE, "Packet found"));
+        // Remove all older packets
+        buffer->tail = (buffer->tail + index) % buffer->size;
+        buffer->count -= index;
+        return PJ_TRUE;
+    } else {
+        PJ_LOG(3,(THIS_FILE, "Packet not found"));
+        // Remove all older packets
+        buffer->tail = (buffer->tail + index + 1) % buffer->size;
+        buffer->count -= index + 1;
+        return PJ_FALSE;
+    }
+}
+
+unsigned pjmedia_nack_buffer_len(pjmedia_nack_buffer *buffer) {
+    return buffer->count;
+}
+

--- a/pjmedia/src/pjmedia/nack_buffer.c
+++ b/pjmedia/src/pjmedia/nack_buffer.c
@@ -76,8 +76,6 @@ pjmedia_nack_buffer_push(pjmedia_nack_buffer *buffer,
         buffer->tail = (buffer->tail + 1) % buffer->size;
     }
 
-    PJ_LOG(3, (THIS_FILE, "Nacked packet with pid: %u, blp: %u was added!", nack.pid, nack.blp));
-
     buffer->packets[buffer->head] = nack;
     buffer->head = (buffer->head + 1) % buffer->size;
 

--- a/pjmedia/src/pjmedia/nack_buffer.c
+++ b/pjmedia/src/pjmedia/nack_buffer.c
@@ -51,12 +51,16 @@ pjmedia_nack_buffer_create(pj_pool_t *pool,
     return PJ_SUCCESS;
 }
 
-PJ_DEF(void)
+PJ_DEF(pj_status_t)
 pjmedia_nack_buffer_reset(pjmedia_nack_buffer *buffer) {
+    PJ_ASSERT_RETURN(buffer, PJ_EINVAL);
+
     PJ_LOG(3, (THIS_FILE, "Nack buffer restarted."));
     buffer->count = 0;
     buffer->head = 0;
     buffer->tail = 0;
+
+    return PJ_SUCCESS;
 }
 
 PJ_DEF(pj_status_t)

--- a/pjmedia/src/pjmedia/nack_buffer.c
+++ b/pjmedia/src/pjmedia/nack_buffer.c
@@ -66,8 +66,7 @@ pjmedia_nack_buffer_push(pjmedia_nack_buffer *buffer,
         buffer->tail = (buffer->tail + 1) % buffer->size;
     }
 
-    PJ_LOG(3, (THIS_FILE, "debug Nacked packet with pid: %u, blp: %u was added!", nack.pid, nack.blp));
-    PJ_LOG(3, (THIS_FILE, "debug Buffer length: %u.", buffer->count));
+    PJ_LOG(3, (THIS_FILE, "Nacked packet with pid: %u, blp: %u was added!", nack.pid, nack.blp));
 
     buffer->packets[buffer->head] = nack;
     buffer->head = (buffer->head + 1) % buffer->size;
@@ -79,6 +78,7 @@ pjmedia_nack_buffer_push(pjmedia_nack_buffer *buffer,
 PJ_DECL(pj_bool_t)
 pjmedia_nack_buffer_frame_dequeued(pjmedia_nack_buffer *buffer,
                                    pj_uint16_t sequence_num) {
+
     if (buffer->count == 0) {
         return PJ_FALSE; 
     }
@@ -121,10 +121,7 @@ pjmedia_nack_buffer_frame_dequeued(pjmedia_nack_buffer *buffer,
     buffer->tail = (buffer->tail + index + 1) % buffer->size;
     buffer->count -= index + 1;
 
-     PJ_LOG(3, (THIS_FILE, "debug Buffer length: %u", buffer->count));
-
     if (packet->pid == sequence_num || blp_contains(packet, sequence_num)) {
-        PJ_LOG(3, (THIS_FILE, "debug Nacked packet %u was played", sequence_num));
         return PJ_TRUE;
     } else {
         return PJ_FALSE;

--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -2057,6 +2057,7 @@ static void on_rx_rtp( pjmedia_tp_cb_param *param)
      */
     pj_mutex_lock( stream->jb_mutex );
     if (seq_st.status.flag.restart) {
+        pjmedia_nack_buffer_reset(stream->nack_buffer);
         status = pjmedia_jbuf_reset(stream->jb);
         PJ_LOG(4,(stream->port.info.name.ptr, "Jitter buffer reset"));
     } else {
@@ -3261,6 +3262,7 @@ PJ_DEF(pj_status_t) pjmedia_stream_pause( pjmedia_stream *stream,
         /* Also reset jitter buffer */
         pj_mutex_lock( stream->jb_mutex );
         pjmedia_jbuf_reset(stream->jb);
+        pjmedia_nack_buffer_reset(stream->nack_buffer);
         pj_mutex_unlock( stream->jb_mutex );
 
         PJ_LOG(4,(stream->port.info.name.ptr, "Decoder stream paused"));

--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -21,6 +21,7 @@
 #include <pjmedia/rtp.h>
 #include <pjmedia/rtcp.h>
 #include <pjmedia/jbuf.h>
+#include <pjmedia/nack_buffer.h>
 #include <pj/array.h>
 #include <pj/assert.h>
 #include <pj/ctype.h>
@@ -164,6 +165,8 @@ struct pjmedia_stream
     char                     jb_last_frm;   /**< Last frame type from jb    */
     unsigned                 jb_last_frm_cnt;/**< Last JB frame type counter*/
     unsigned                 soft_start_cnt;/**< Stream soft start counter */
+
+    pjmedia_nack_buffer     *nack_buffer;    /**< Nack buffer                */
 
     pjmedia_rtcp_session     rtcp;          /**< RTCP for incoming RTP.     */
 
@@ -590,8 +593,14 @@ static pj_status_t get_frame( pjmedia_port *port, pjmedia_frame *frame)
         }
 
         /* Get frame from jitter buffer. */
+        pj_uint16_t packet_seq;
         pjmedia_jbuf_get_frame2(stream->jb, channel->out_pkt, &frame_size,
-                                &frame_type, &bit_info);
+                                &frame_type, &bit_info, &packet_seq);
+        
+        pj_bool_t is_nacked_frame = pjmedia_nack_buffer_frame_dequeued(stream->nack_buffer, packet_seq);
+        if (is_nacked_frame) {
+            stream->rtcp.stat.tx.useful_nack_cnt += 1;
+        }
 
 #if TRACE_JB
         trace_jb_get(stream, frame_type, frame_size);
@@ -871,8 +880,14 @@ static pj_status_t get_frame_ext( pjmedia_port *port, pjmedia_frame *frame)
         pj_mutex_lock( stream->jb_mutex );
 
         /* Get frame from jitter buffer. */
+        pj_uint16_t packet_seq; 
         pjmedia_jbuf_get_frame2(stream->jb, channel->out_pkt, &frame_size,
-                                &frame_type, &bit_info);
+                                &frame_type, &bit_info, &packet_seq);
+
+        pj_bool_t is_nacked_frame = pjmedia_nack_buffer_frame_dequeued(stream->nack_buffer, packet_seq);
+        if (is_nacked_frame) {
+            stream->rtcp.stat.tx.useful_nack_cnt += 1;
+        }
 
 #if TRACE_JB
         trace_jb_get(stream, frame_type, frame_size);
@@ -2173,7 +2188,7 @@ static void on_rx_rtp( pjmedia_tp_cb_param *param)
 
             ext_seq = (unsigned)(frames[i].timestamp.u64 / ts_span);
             pjmedia_jbuf_put_frame2(stream->jb, frames[i].buf, frames[i].size,
-                                    frames[i].bit_info, ext_seq, &discarded);
+                                    frames[i].bit_info, ext_seq, &discarded, hdr->seq);
             if (discarded)
                 pkt_discarded = PJ_TRUE;
         }
@@ -2222,6 +2237,11 @@ on_return:
             stream->rtcp_fb_nack.blp |= 1;
         }
         stream->rtcp.stat.tx.nack_cnt += seq_st.diff - 1;
+        status = pjmedia_nack_buffer_push(stream->nack_buffer, stream->rtcp_fb_nack);
+
+        if (status != PJ_SUCCESS) {
+           PJ_PERROR(4,(THIS_FILE, status, "Failed to push NACK packet to the buffer"));
+        }
 
         /* Send it immediately */
         status = send_rtcp(stream, PJ_TRUE, PJ_FALSE, PJ_FALSE, PJ_TRUE);
@@ -2723,6 +2743,11 @@ PJ_DEF(pj_status_t) pjmedia_stream_create( pjmedia_endpt *endpt,
                                  jb_max, &stream->jb);
     if (status != PJ_SUCCESS)
         goto err_cleanup;
+    
+    status = pjmedia_nack_buffer_create(pool, 100, &stream->nack_buffer);
+    if (status != PJ_SUCCESS) {
+        goto err_cleanup; 
+    }
 
 
     /* Set up jitter buffer */

--- a/pjmedia/src/pjmedia/stream.c
+++ b/pjmedia/src/pjmedia/stream.c
@@ -2221,6 +2221,7 @@ on_return:
             stream->rtcp_fb_nack.blp <<= 1;
             stream->rtcp_fb_nack.blp |= 1;
         }
+        stream->rtcp.stat.tx.nack_cnt += seq_st.diff - 1;
 
         /* Send it immediately */
         status = send_rtcp(stream, PJ_TRUE, PJ_FALSE, PJ_FALSE, PJ_TRUE);

--- a/pjmedia/src/pjmedia/vid_stream.c
+++ b/pjmedia/src/pjmedia/vid_stream.c
@@ -973,7 +973,7 @@ static void on_rx_rtp( pjmedia_tp_cb_param *param)
     } else {
         /* Just put the payload into jitter buffer */
         pjmedia_jbuf_put_frame3(stream->jb, payload, payloadlen, 0,
-                                pj_ntohs(hdr->seq), pj_ntohl(hdr->ts), NULL);
+                                pj_ntohs(hdr->seq), pj_ntohl(hdr->ts), NULL, 0);
 
 #if TRACE_JB
         trace_jb_put(stream, hdr, payloadlen, count);

--- a/pjmedia/src/test/nack_buffer_test.c
+++ b/pjmedia/src/test/nack_buffer_test.c
@@ -1,0 +1,241 @@
+#include <pjmedia/nack_buffer.h>
+#include <pj/math.h>
+#include "test.h"
+
+#define THIS_FILE   "nack_buffer_test.c"
+#define BUFFER_SIZE 5
+
+static int test_that_new_packets_added(pjmedia_nack_buffer *buffer) {
+    unsigned index;
+    for (index = 0; index <= PJ_MAX(BUFFER_SIZE, 10); index++) {
+        pjmedia_rtcp_fb_nack nack;
+        nack.pid = (uint16_t)index;
+        nack.blp = 0;
+        pj_status_t result = pjmedia_nack_buffer_push(buffer, nack);
+        if (result != PJ_SUCCESS) {
+            return result; 
+        }
+        unsigned length = pjmedia_nack_buffer_len(buffer);
+        unsigned expected_length = PJ_MIN(index + 1, BUFFER_SIZE);
+        if (length != expected_length) {
+            PJ_LOG(3, (THIS_FILE, "nack_buffer length is incorrect: Expected: %u. Real: %u", expected_length, length));
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static int test_that_packet_is_found_in_buffer_by_pid(pjmedia_nack_buffer *buffer) {
+    pjmedia_rtcp_fb_nack first_nack;
+    pjmedia_rtcp_fb_nack second_nack;
+    first_nack.pid = 1;
+    first_nack.blp = 0;
+    second_nack.pid = 2;
+    second_nack.blp = 0;
+
+    pj_status_t first_push_result = pjmedia_nack_buffer_push(buffer, first_nack);
+    if (first_push_result != PJ_SUCCESS) {
+        return first_push_result; 
+    }
+    pj_status_t second_push_result = pjmedia_nack_buffer_push(buffer, second_nack); 
+    if (second_push_result != PJ_SUCCESS) {
+        return second_push_result; 
+    }
+
+    pj_bool_t is_first_packet_found = pjmedia_nack_buffer_frame_dequeued(buffer, 1);
+    pj_bool_t is_second_packet_found = pjmedia_nack_buffer_frame_dequeued(buffer, 2);
+
+    if (!is_first_packet_found || !is_second_packet_found) {
+        PJ_LOG(3,(THIS_FILE, "Packet was not found in nack buffer"));
+        return -1;
+    }
+    unsigned length = pjmedia_nack_buffer_len(buffer);
+    if (length != 1) {
+        PJ_LOG(3,(THIS_FILE, "nack buffer must have one packet"));
+        return -1; 
+    }
+    return 0;
+}
+
+static int test_that_packet_is_found_in_buffer_by_blp(pjmedia_nack_buffer *buffer) {
+    pjmedia_rtcp_fb_nack first_nack;
+    pjmedia_rtcp_fb_nack second_nack;
+    first_nack.pid = 1;
+    first_nack.blp = 0b11;
+    second_nack.pid = 20;
+    second_nack.blp = 0b1;
+
+    pj_status_t first_push_result = pjmedia_nack_buffer_push(buffer, first_nack);
+    if (first_push_result != PJ_SUCCESS) {
+        return first_push_result; 
+    }
+    pj_status_t second_push_result = pjmedia_nack_buffer_push(buffer, second_nack); 
+    if (second_push_result != PJ_SUCCESS) {
+        return second_push_result; 
+    }
+
+    unsigned lost_packets[3] = { 2, 3, 21 };
+    unsigned index;
+    for (index = 0; index < 3; index++) {
+        pj_bool_t is_packet_found = pjmedia_nack_buffer_frame_dequeued(buffer, lost_packets[index]);
+        if (!is_packet_found) {
+           PJ_LOG(3,(THIS_FILE, "Packet %u was not found in nack buffer", lost_packets[index])); 
+           return -1;
+        }
+    }
+    unsigned length = pjmedia_nack_buffer_len(buffer);
+    if (length != 1) {
+        PJ_LOG(3,(THIS_FILE, "nack buffer must have one packet"));
+        return -1; 
+    }
+    return 0;
+}
+
+static int test_that_not_added_packet_is_not_found_in_buffer(pjmedia_nack_buffer *buffer) {
+    pjmedia_rtcp_fb_nack first_nack;
+    pjmedia_rtcp_fb_nack second_nack;
+    first_nack.pid = 1;
+    first_nack.blp = 0b11;
+    second_nack.pid = 20;
+    second_nack.blp = 0b1;
+
+    pjmedia_nack_buffer_push(buffer, first_nack);
+    pjmedia_nack_buffer_push(buffer, second_nack); 
+
+    unsigned not_added_packets[3] = { 4, 22, 50 };
+    unsigned index;
+    for (index = 0; index < 3; index++) {
+        pj_bool_t is_packet_found = pjmedia_nack_buffer_frame_dequeued(buffer, not_added_packets[index]);
+        if (is_packet_found) {
+           PJ_LOG(3,(THIS_FILE, "Unexpeted packet %u was found in nack buffer", not_added_packets[index])); 
+           return -1;
+        }
+    }
+    unsigned length = pjmedia_nack_buffer_len(buffer);
+    if (length > 0) {
+        PJ_LOG(3,(THIS_FILE, "nack buffer must be empty"));
+        return -1; 
+    }
+    return 0;
+}
+
+static int test_that_old_packets_removed_from_buffer_when_new_packet_added(pjmedia_nack_buffer *buffer) {
+    uint16_t packets[8] = { 1, 20, 45, 78, 100, 120, 150, 240 };
+    unsigned index;
+
+    for (index = 0; index < PJ_ARRAY_SIZE(packets); index++) {
+        pjmedia_rtcp_fb_nack nack; 
+        nack.pid = packets[index];
+        nack.blp = 0;
+        pj_status_t status = pjmedia_nack_buffer_push(buffer, nack); 
+        if (status != PJ_SUCCESS) {
+            return status;
+        }
+        if (index < BUFFER_SIZE) {
+            continue; 
+        }
+        pj_bool_t is_packet_found = pjmedia_nack_buffer_frame_dequeued(buffer, packets[index - BUFFER_SIZE]);
+        if (is_packet_found) {
+            PJ_LOG(3,(THIS_FILE, "Unexpeted packet %u was found in nack buffer", packets[index - BUFFER_SIZE])); 
+            return -1;
+        }
+    }
+    for (index = BUFFER_SIZE; index < PJ_ARRAY_SIZE(packets); index ++)  {
+        pj_bool_t is_packet_found = pjmedia_nack_buffer_frame_dequeued(buffer, packets[index]);
+        if (!is_packet_found) {
+            PJ_LOG(3,(THIS_FILE, "Packet %u was not found in nack buffer", packets[index])); 
+            return -1;
+        } 
+    }
+    return 0;
+}
+
+static int test_that_old_packets_removed_from_buffer_when_more_recent_packet_played(pjmedia_nack_buffer *buffer) {
+    uint16_t packets[8] = { 1, 20, 45, 78, 100, 120, 150, 240 };
+    unsigned index;
+
+    for (index = 0; index < PJ_ARRAY_SIZE(packets); index++) {
+        pjmedia_rtcp_fb_nack nack; 
+        nack.pid = packets[index];
+        nack.blp = 0;
+        pjmedia_nack_buffer_push(buffer, nack);
+    }
+
+    int played_packets[3] = { 115, 125, 300 };
+    unsigned expected_length[3] = { 3, 2, 0 };
+    for (index = 0; index < PJ_ARRAY_SIZE(played_packets); index++) {
+        pj_bool_t is_packet_found = pjmedia_nack_buffer_frame_dequeued(buffer, played_packets[index]);
+        PJ_ASSERT_RETURN(!is_packet_found, -1);
+
+        unsigned length = pjmedia_nack_buffer_len(buffer);
+        if (length != expected_length[index]) {
+            PJ_LOG(3,(THIS_FILE, "Unexpected buffer length: %u. Expected: %u", length, expected_length[index]));
+            return -1; 
+        }
+    }
+    return 0;
+}
+
+static struct test
+{
+    const char *title;
+    int (*test_function)(pjmedia_nack_buffer*);
+} test[] =
+{
+    {
+        "Nack buffer push",
+        test_that_new_packets_added 
+    },
+    {
+        "Find packet by PID in nack buffer",
+        test_that_packet_is_found_in_buffer_by_pid 
+    },
+    {
+        "Find packet by BLP in nack buffer",
+        test_that_packet_is_found_in_buffer_by_blp
+    },
+    {
+        "Not added packets not found in nack buffer",
+        test_that_not_added_packet_is_not_found_in_buffer 
+    },
+    {
+        "Old packet removed when new packet added",
+        test_that_old_packets_removed_from_buffer_when_new_packet_added
+    },
+    {
+        "Old packet removed when frame from more recent packet played",
+        test_that_old_packets_removed_from_buffer_when_more_recent_packet_played
+    }
+};
+
+int nack_buffer_test()
+{
+    pj_pool_t *pool = pj_pool_create(mem, "nack_buffer_test", 4000, 4000, NULL);
+    if (!pool) {
+        return PJ_ENOMEM;
+    }
+
+    unsigned test_index;
+    int result;
+    for (test_index = 0; test_index < PJ_ARRAY_SIZE(test); test_index++) {
+        PJ_LOG(3, (THIS_FILE,"  test %d: %s", test_index, test[test_index].title));
+
+        pjmedia_nack_buffer *buffer;
+        pj_status_t status = pjmedia_nack_buffer_create(pool, BUFFER_SIZE, &buffer);
+        if (status != PJ_SUCCESS) {
+            result = status;
+            break;
+        }
+
+        int test_result = test[test_index].test_function(buffer);
+        if (test_result != 0) {
+            result = test_result;
+            break;
+        } else {
+            PJ_LOG(3,(THIS_FILE, "%s test succeeded", test[test_index].title));
+        }
+    }
+
+    pj_pool_release(pool);
+    return -1;
+}

--- a/pjmedia/src/test/nack_buffer_test.c
+++ b/pjmedia/src/test/nack_buffer_test.c
@@ -219,6 +219,24 @@ static int test_that_packet_found_by_blp_when_integer_overflow_happend(pjmedia_n
     return 0;
 }
 
+static int test_buffer_reset(pjmedia_nack_buffer *buffer) {
+    unsigned index;
+    for (index = 0; index <= PJ_MAX(BUFFER_SIZE, 10); index++) {
+        pjmedia_rtcp_fb_nack nack;
+        nack.pid = (uint16_t)index;
+        nack.blp = 0;
+        pj_status_t result = pjmedia_nack_buffer_push(buffer, nack);
+        if (result != PJ_SUCCESS) {
+            return result; 
+        }
+    }
+    if (pjmedia_nack_buffer_len(buffer) > 0) {
+        PJ_LOG(3, (THIS_FILE, "Nack buffer must be empty."));
+        return -1;
+    }
+    return 0;
+}
+
 static struct test
 {
     const char *title;
@@ -256,6 +274,10 @@ static struct test
     {
         "Packet found by BLP when integer overflow happend",
         test_that_packet_found_by_blp_when_integer_overflow_happend
+    },
+    {
+        "Buffer reset",
+        test_buffer_reset
     }
 };
 

--- a/pjmedia/src/test/nack_buffer_test.c
+++ b/pjmedia/src/test/nack_buffer_test.c
@@ -230,6 +230,7 @@ static int test_buffer_reset(pjmedia_nack_buffer *buffer) {
             return result; 
         }
     }
+    pjmedia_nack_buffer_reset(buffer);
     if (pjmedia_nack_buffer_len(buffer) > 0) {
         PJ_LOG(3, (THIS_FILE, "Nack buffer must be empty."));
         return -1;

--- a/pjmedia/src/test/test.c
+++ b/pjmedia/src/test/test.c
@@ -98,6 +98,9 @@ int test_main(void)
 #if HAS_JBUF_TEST
     DO_TEST(jbuf_main());
 #endif
+#if HAS_NACK_BUFFER_TEST
+    DO_TEST(nack_buffer_test());
+#endif
 #if HAS_MIPS_TEST
     DO_TEST(mips_test());
 #endif

--- a/pjmedia/src/test/test.h
+++ b/pjmedia/src/test/test.h
@@ -37,11 +37,13 @@
 #define HAS_JBUF_TEST           1
 #define HAS_MIPS_TEST           WITH_BENCHMARK
 #define HAS_CODEC_VECTOR_TEST   1
+#define HAS_NACK_BUFFER_TEST    1
 
 int session_test(void);
 int rtp_test(void);
 int sdp_test(void);
 int jbuf_main(void);
+int nack_buffer_test(void);
 int sdp_neg_test(void);
 int mips_test(void);
 int codec_test_vectors(void);

--- a/pjsip/include/pjsua2/call.hpp
+++ b/pjsip/include/pjsua2/call.hpp
@@ -100,6 +100,8 @@ struct RtcpStreamStat
     unsigned        loss;       /**< Total number of packets lost           */
     unsigned        reorder;    /**< Total number of out of order packets   */
     unsigned        dup;        /**< Total number of duplicates packets     */
+    unsigned        nackCount;  /**< Total number of NACK packets           */
+    unsigned        usefulNackCount;/**< Total number of played NACK packets*/
     
     MathStat        lossPeriodUsec; /**< Loss period statistics             */
 

--- a/pjsip/include/pjsua2/call.hpp
+++ b/pjsip/include/pjsua2/call.hpp
@@ -671,7 +671,7 @@ public:
     void fromPj(const pjsua_stream_info &info);
 };
 
-#if defined(PJMEDIA_HAS_OPUS_CODEC) && (PJMEDIA_HAS_OPUS_CODEC==0)
+#if defined(PJMEDIA_HAS_OPUS_CODEC) && (PJMEDIA_HAS_OPUS_CODEC!=0)
 
 /**
  * OPUS codec status.
@@ -711,7 +711,7 @@ struct StreamStat
      */
     JbufState   jbuf;
 
-#if defined(PJMEDIA_HAS_OPUS_CODEC) && (PJMEDIA_HAS_OPUS_CODEC==0)
+#if defined(PJMEDIA_HAS_OPUS_CODEC) && (PJMEDIA_HAS_OPUS_CODEC!=0)
 
     /**
      * OPUS codec stat

--- a/pjsip/include/pjsua2/call.hpp
+++ b/pjsip/include/pjsua2/call.hpp
@@ -92,22 +92,22 @@ struct LossType
  */
 struct RtcpStreamStat
 {
-    TimeVal         update;     /**< Time of last update.                   */
-    unsigned        updateCount;/**< Number of updates (to calculate avg)   */
-    unsigned        pkt;        /**< Total number of packets                */
-    unsigned        bytes;      /**< Total number of payload/bytes          */
-    unsigned        discard;    /**< Total number of discarded packets.     */
-    unsigned        loss;       /**< Total number of packets lost           */
-    unsigned        reorder;    /**< Total number of out of order packets   */
-    unsigned        dup;        /**< Total number of duplicates packets     */
-    unsigned        nackCount;  /**< Total number of NACK packets           */
-    unsigned        usefulNackCount;/**< Total number of played NACK packets*/
+    TimeVal         update;     /**< Time of last update.                           */
+    unsigned        updateCount;/**< Number of updates (to calculate avg)           */
+    unsigned        pkt;        /**< Total number of packets                        */
+    unsigned        bytes;      /**< Total number of payload/bytes                  */
+    unsigned        discard;    /**< Total number of discarded packets.             */
+    unsigned        loss;       /**< Total number of packets lost                   */
+    unsigned        reorder;    /**< Total number of out of order packets           */
+    unsigned        dup;        /**< Total number of duplicates packets             */
+    unsigned        nackCount;  /**< Total number of packets requested using NACK   */
+    unsigned        usefulNackCount;/**< Total number of played NACK packets        */
     
-    MathStat        lossPeriodUsec; /**< Loss period statistics             */
+    MathStat        lossPeriodUsec; /**< Loss period statistics                     */
 
-    LossType        lossType;   /**< Types of loss detected.                */
+    LossType        lossType;   /**< Types of loss detected.                        */
     
-    MathStat        jitterUsec; /**< Jitter statistics                      */
+    MathStat        jitterUsec; /**< Jitter statistics                              */
     
 public:
     /**
@@ -671,7 +671,7 @@ public:
     void fromPj(const pjsua_stream_info &info);
 };
 
-#if defined(PJMEDIA_HAS_OPUS_CODEC) && (PJMEDIA_HAS_OPUS_CODEC!=0)
+#if defined(PJMEDIA_HAS_OPUS_CODEC) && (PJMEDIA_HAS_OPUS_CODEC==0)
 
 /**
  * OPUS codec status.
@@ -711,7 +711,7 @@ struct StreamStat
      */
     JbufState   jbuf;
 
-#if defined(PJMEDIA_HAS_OPUS_CODEC) && (PJMEDIA_HAS_OPUS_CODEC!=0)
+#if defined(PJMEDIA_HAS_OPUS_CODEC) && (PJMEDIA_HAS_OPUS_CODEC==0)
 
     /**
      * OPUS codec stat

--- a/pjsip/src/pjsua2/call.cpp
+++ b/pjsip/src/pjsua2/call.cpp
@@ -58,6 +58,8 @@ void RtcpStreamStat::fromPj(const pjmedia_rtcp_stream_stat &prm)
     this->loss            = prm.loss;
     this->reorder         = prm.loss;
     this->dup             = prm.dup;
+    this->nackCount       = prm.nack_cnt;
+    this->usefulNackCount = prm.useful_nack_cnt;
     this->lossPeriodUsec.fromPj(prm.loss_period);
     this->lossType.burst  = prm.loss_type.burst;
     this->lossType.random = prm.loss_type.random;


### PR DESCRIPTION
### Task
- [[R&D] iOS: NACK analytics](https://jira.imsecurityproducts.net/browse/APPS-10528)

### Changes:
In this task, our goal was to count the number of NACKed RTP packets and the number of played packets that had been NACKed. To achieve this, I extended the `pjmedia_rtcp_stream_stat` structure and introduced `nack_cnt` and `useful_nack_cnt` fields.

The `nack_cnt` field represents the total number of requested packets, while `useful_nack_cnt` denotes the total number of played packets that were previously requested.

The `nack_cnt` field is updated with each sent NACK RTCP feedback, taking into account the number of requested packets.
Calculating the `useful_nack_cnt` requires storing the sequence numbers of NACKed packets and subsequently checking if they were fetched from the jitter buffer.

I added the `pjmedia_nack_buffer` structure, which is a ring buffer used to store the sequence numbers of NACKed packets.
The `pjmedia_nack_buffer_create` function is used to instantiate the buffer with a specified size. Currently, the buffer size is set to 20. During my tests, the buffer's length never exceeded three stored items.

The `pjmedia_nack_buffer_push` function is used to push the sequence number (PID) of the missed packet and the bitmask of following lost packets (BLP).

The `pjmedia_nack_buffer_frame_dequeued` function checks if a frame retrieved from the jitter buffer was NACKed. As PIDs are added in ascending order, we can use binary search to check if a packet with the same or a lower PID exists in the buffer. Additionally, we can remove all packets with older sequence numbers, as they will not be played.

I have also added tests for this buffer in the `nack_buffer_test.c` file.