### PR TITLE
Update TFS pipeline to upload iOS artifact to existing GH release

### DIFF
--- a/.azure/build_ios_framework.yml
+++ b/.azure/build_ios_framework.yml
@@ -4,7 +4,7 @@ pool:
 
 steps:
   - script: |
-      find $(Build.ArtifactStagingDirectory)/* -delete
+      rm -rf ./$(Build.ArtifactStagingDirectory)/*
       cd ios_framework
       ./build_ios_framework.sh --source-dir=$(Build.SourcesDirectory) --output-dir="$PWD/artifact" --name="pjsip-ios-$(Build.SourceBranchName)"
     displayName: 'Build framework'
@@ -16,9 +16,10 @@ steps:
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
   - task: GitHubRelease@1
-    displayName: 'Create GitHub release'
+    displayName: 'Update GitHub release'
     inputs:
       gitHubConnection: 'Github PJSIP'
-      title: 'PJSIP iOS $(Build.SourceBranchName)'
-      isDraft: true
-      addChangeLog: false
+      action: edit
+      tag: $(Build.SourceBranchName)
+      assets: '$(Build.ArtifactStagingDirectory)/*'
+      assetUploadMode: 'replace'

--- a/.azure/build_ios_framework.yml
+++ b/.azure/build_ios_framework.yml
@@ -3,8 +3,13 @@ pool:
   demands: isSupportsIOS -equals true
 
 steps:
+  - task: DeleteFiles@1
+    inputs:
+      sourceFolder: '$(Build.ArtifactStagingDirectory)'
+      contents: '**'
+      clean: true
+
   - script: |
-      rm -rf ./$(Build.ArtifactStagingDirectory)/*
       cd ios_framework
       ./build_ios_framework.sh --source-dir=$(Build.SourcesDirectory) --output-dir="$PWD/artifact" --name="pjsip-ios-$(Build.SourceBranchName)"
     displayName: 'Build framework'
@@ -14,6 +19,12 @@ steps:
     inputs:
       SourceFolder: './ios_framework/artifact'
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
+    
+  - task: DeleteFiles@1
+    inputs:
+      sourceFolder: '$(Build.SourcesDirectory)/ios_framework/artifact'
+      contents: '**'
+      clean: true
 
   - task: GitHubRelease@1
     displayName: 'Update GitHub release'

--- a/pjlib/include/pj/config.h
+++ b/pjlib/include/pj/config.h
@@ -1415,7 +1415,7 @@ PJ_BEGIN_DECL
  * Extra suffix for the version (e.g. "-trunk"), or empty for
  * web release version.
  */
-#define PJ_VERSION_NUM_EXTRA	"-6"
+#define PJ_VERSION_NUM_EXTRA	"-8"
 
 /**
  * PJLIB version number consists of three bytes with the following format:

--- a/version.mak
+++ b/version.mak
@@ -2,7 +2,7 @@
 export PJ_VERSION_MAJOR  := 2
 export PJ_VERSION_MINOR  := 13
 export PJ_VERSION_REV    :=
-export PJ_VERSION_SUFFIX := -6
+export PJ_VERSION_SUFFIX := -8
 
 export PJ_VERSION := $(PJ_VERSION_MAJOR).$(PJ_VERSION_MINOR)
 


### PR DESCRIPTION
TFS pipeline to build iOS framework was updated to not create new GH release, but update existing release with built artifact instead.

### Changes:
- `find <path> -delete` command was used in pipeline to delete artifacts created in previous runs. But for some reason this command do not work in TFS pipeline and prints that passed directory do not exist. I replaced it with separate DeleteFiles steps.
- "Create GitHub release" step was replaced with "Update GitHub release" to update existing release with built artifact.
- `PJ_VERSION_SUFFIX` and `PJ_VERSION_NUM_EXTRA` variables was updated according to next release version.