### PR TITLE
Add swift file to fix pod installation

### DIFF
--- a/ios_framework/Sources/LibHelper.swift
+++ b/ios_framework/Sources/LibHelper.swift
@@ -1,0 +1,12 @@
+//
+//  LibHelper.swift
+//  Pods
+//
+//  Created by Dmitriy Shamaev on 21.03.2022.
+//
+
+import Foundation
+
+final class LibHelper {}
+
+// do not delete this file or pjsip library won't be able to be linked dynamically into pure Swift project


### PR DESCRIPTION
Add Swift file because otherwise USIP pod installation failed, because PJSIP library became static without swift file.