### PR TITLE
APPS-14269: Update openssl version to 3.2.0, bump pjproject version t…

### DIFF
--- a/ios_framework/openssl/openssl.sh
+++ b/ios_framework/openssl/openssl.sh
@@ -6,7 +6,7 @@
 ###########################################################################
 #  Change values here                                                     #
 #                                                                         #
-VERSION="1.1.1n"                                                           #  
+VERSION="3.2.0"                                                           #  
 if test "x${MIN_IOS_VERSION}" = "x"; then
   MIN_IOS_VERSION="14.0"
   echo "$F: MIN_IOS_VERSION is not specified, using ${MIN_IOS_VERSION}"
@@ -78,7 +78,7 @@ _build() {
     export CROSS_TOP=`xcrun -sdk $SDK --show-sdk-platform-path`/Developer
     export CROSS_SDK="${PLATFORM}.sdk"
     export BUILD_TOOLS="${DEVELOPER}"
-    export CC="${BUILD_TOOLS}/usr/bin/gcc -fembed-bitcode -arch ${ARCH}"
+    export CC="${BUILD_TOOLS}/usr/bin/gcc -arch ${ARCH}"
 
     BUILD_LOG="${INSTALL_DIR}/build-openssl-${VERSION}.log"
     CONFIG_LOG="${INSTALL_DIR}/config-openssl-${VERSION}.log"
@@ -88,9 +88,9 @@ _build() {
 
     if [ "$SDK" == "iphonesimulator" ];
     then
-        ./Configure iossimulator-xcrun "-arch $ARCH -fembed-bitcode" ${OPENSSL_CONFIGURE_OPTIONS} --prefix="${INSTALL_DIR}" --openssldir="${INSTALL_DIR}" &> "${CONFIG_LOG}"
+        ./Configure iossimulator-xcrun "-arch $ARCH" ${OPENSSL_CONFIGURE_OPTIONS} --prefix="${INSTALL_DIR}" --openssldir="${INSTALL_DIR}" &> "${CONFIG_LOG}"
     else
-        ./Configure iphoneos-cross DSO_LDFLAGS=-fembed-bitcode --prefix="${INSTALL_DIR}" $ios_version_flag ${OPENSSL_CONFIGURE_OPTIONS} --openssldir="${INSTALL_DIR}" &> "${CONFIG_LOG}"
+        ./Configure iphoneos-cross --prefix="${INSTALL_DIR}" $ios_version_flag ${OPENSSL_CONFIGURE_OPTIONS} --openssldir="${INSTALL_DIR}" &> "${CONFIG_LOG}"
     fi
 
     if [ $? != 0 ];

--- a/pjlib/include/pj/config.h
+++ b/pjlib/include/pj/config.h
@@ -1502,7 +1502,7 @@ PJ_BEGIN_DECL
  * Extra suffix for the version (e.g. "-trunk"), or empty for
  * web release version.
  */
-#define PJ_VERSION_NUM_EXTRA	"-1"
+#define PJ_VERSION_NUM_EXTRA	"-3"
 
 /**
  * PJLIB version number consists of three bytes with the following format:

--- a/version.mak
+++ b/version.mak
@@ -2,7 +2,7 @@
 export PJ_VERSION_MAJOR  := 2
 export PJ_VERSION_MINOR  := 14
 export PJ_VERSION_REV    :=
-export PJ_VERSION_SUFFIX := -1
+export PJ_VERSION_SUFFIX := -3
 
 export PJ_VERSION := $(PJ_VERSION_MAJOR).$(PJ_VERSION_MINOR)
 


### PR DESCRIPTION
- Updated OpenSSL to version 3.2
- Removed the use of the `-fembed-bitcode` flag because we were encountering an error during the build of OpenSSL `ld: -bundle and -bitcode_bundle (Xcode setting ENABLE_BITCODE=YES) cannot be used together`
- Bumped version to 2.14-3