### PR TITLE
Add desktop build scripts

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -1,0 +1,40 @@
+name: Linux release
+
+on:
+  push:
+    tags:
+      - '*'
+
+env:
+  RELEASE_ARCHIVE_NAME: linux-release
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: read
+    steps:
+      - name: Pre-requirements
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build
+        run: |
+          cd build-scripts
+          sudo ./build
+      - name: Archive artifacts
+        if: always()
+        run: |
+          tar -czvf "$RELEASE_ARCHIVE_NAME".tar.gz -C build-scripts/work/result .
+      - name: Publish release
+        if: always()
+        id: update_release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ github.ref_name }}
+          artifacts: ${{ env.RELEASE_ARCHIVE_NAME }}.tar.gz
+          allowUpdates: true
+          omitNameDuringUpdate: true

--- a/.github/workflows/macos-arm64-release.yml
+++ b/.github/workflows/macos-arm64-release.yml
@@ -1,0 +1,40 @@
+name: MacOs arm64 release
+
+on:
+  push:
+    tags:
+      - '*'
+
+env:
+  RELEASE_ARCHIVE_NAME: macOS-arm64-release
+
+jobs:
+  build-macos-arm64:
+    runs-on: macos-14
+    permissions:
+      contents: write
+      packages: read
+    steps:
+      - name: Pre-requirements
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build
+        run: |
+          cd build-scripts
+          sudo ./build
+      - name: Archive artifacts
+        if: always()
+        run: |
+          tar -czvf "$RELEASE_ARCHIVE_NAME".tar.gz -C build-scripts/work/result .
+      - name: Publish release
+        if: always()
+        id: update_release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ github.ref_name }}
+          artifacts: ${{ env.RELEASE_ARCHIVE_NAME }}.tar.gz
+          allowUpdates: true
+          omitNameDuringUpdate: true

--- a/.github/workflows/macos-x86-release.yml
+++ b/.github/workflows/macos-x86-release.yml
@@ -1,0 +1,40 @@
+name: MacOs x86 release
+
+on:
+  push:
+    tags:
+      - '*'
+
+env:
+  RELEASE_ARCHIVE_NAME: macOS-x86-release
+
+jobs:
+  build-macos-x86:
+    runs-on: macos-13
+    permissions:
+      contents: write
+      packages: read
+    steps:
+      - name: Pre-requirements
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build
+        run: |
+          cd build-scripts
+          sudo ./build
+      - name: Archive artifacts
+        if: always()
+        run: |
+          tar -czvf "$RELEASE_ARCHIVE_NAME".tar.gz -C build-scripts/work/result .
+      - name: Publish release
+        if: always()
+        id: update_release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ github.ref_name }}
+          artifacts: ${{ env.RELEASE_ARCHIVE_NAME }}.tar.gz
+          allowUpdates: true
+          omitNameDuringUpdate: true

--- a/build-scripts/build
+++ b/build-scripts/build
@@ -1,0 +1,125 @@
+#!/bin/bash -e
+
+. config.conf
+source ./openssl
+source ./opus
+source ./swig
+
+# the paths are relative (!)
+WORKING_DIR="work"
+PJSUA_SWIG_DIR="pjsip-apps/src/swig"
+CONFIG_SITE_PATH="pjlib/include/pj/config_site.h"
+
+OPUS_DIR="deps/opus"
+OPENSSL_DIR="deps/openssl"
+SWIG_DIR+="deps/swig"
+
+function prepareWorkingDir {
+  rm -rf "$WORKING_DIR/result"
+  export WORKING_DIR="$PWD/work"
+
+  mkdir -p "$WORKING_DIR"
+  cd "$WORKING_DIR"
+  mkdir -p $OPUS_DIR
+  mkdir -p $OPENSSL_DIR
+  mkdir -p $SWIG_DIR
+  mkdir -p result
+}
+
+function installDependencies() {
+  currentDir=$PWD
+  echo "openssl-$OPENSSL_VERSION downloading ..."
+  downloadOpenssl "$OPENSSL_DIR"
+  cd "$currentDir"
+  echo "openssl-$OPENSSL_VERSION building ..."
+  buildOpenssl "$OPENSSL_DIR"
+  cd "$currentDir"
+
+  echo "opus-$OPUS_VERSION downloading ..."
+  downloadOpus "$OPUS_DIR"
+  cd "$currentDir"
+  echo "opus-$OPUS_VERSION building ..."
+  buildOpus "$OPUS_DIR"
+  cd "$currentDir"
+
+  echo "swig-$SWIG_VERSION downloading ..."
+  downloadSwig "$SWIG_DIR"
+  cd "$currentDir"
+  echo "swig-$SWIG_VERSION building ..."
+  buildAndInstallSwig "$SWIG_DIR"
+  cd "$currentDir"
+}
+
+function setConfigSite {
+  echo "#include <pj/config_site_sample.h>" >> "$CONFIG_SITE_PATH"
+  echo "#define PJMEDIA_HAS_VIDEO 0" >> "$CONFIG_SITE_PATH"
+  echo "#define PJMEDIA_AUDIO_DEV_HAS_ANDROID_JNI 0" >> "$CONFIG_SITE_PATH"
+  echo "#define PJMEDIA_AUDIO_DEV_HAS_OPENSL 0" >> "$CONFIG_SITE_PATH"
+  echo "#define PJSIP_AUTH_AUTO_SEND_NEXT 0" >> "$CONFIG_SITE_PATH"
+  echo "#define PJMEDIA_HAS_OPUS_CODEC 1" >> "$CONFIG_SITE_PATH"
+  echo "#define PJSUA_DETECT_MERGED_REQUESTS 0" >> "$CONFIG_SITE_PATH"
+  echo "#define PJ_HAS_IPV6 1" >> "$CONFIG_SITE_PATH"
+}
+
+function buildPjSip {
+  args=(
+    "--with-opus=$WORKING_DIR/$OPUS_DIR/libs"
+    "--with-ssl=$WORKING_DIR/$OPENSSL_DIR/libs"
+  )
+
+  CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure "${args[@]}"
+  make dep
+  make clean
+  make
+
+  cd "${PJSUA_SWIG_DIR}"
+  make
+}
+
+function moveArtifacts() {
+  libDir="$WORKING_DIR/result/lib"
+  includeDir="$WORKING_DIR/result/include"
+  jniDir="$WORKING_DIR/result/jni"
+
+  mkdir -p "$libDir"
+  cp -r "pjsip/lib"/* "$libDir"
+
+  mkdir -p "$includeDir/pjlib"
+  cp -r "pjlib/include"/* "$includeDir/pjlib"
+
+  mkdir -p "$includeDir/pjlib-util"
+  cp -r "pjlib-util/include"/* "$includeDir/pjlib-util"
+
+  mkdir -p "$includeDir/pjmedia"
+  cp -r "pjmedia/include"/* "$includeDir/pjmedia"
+
+  mkdir -p "$includeDir/pjnath"
+  cp -r "pjnath/include"/* "$includeDir/pjnath"
+
+  mkdir -p "$includeDir/pjnat64"
+  cp -r "pjnat64/include"/* "$includeDir/pjnat64"
+
+  mkdir -p "$includeDir/pjsip"
+  cp -r "pjsip/include"/* "$includeDir/pjsip"
+
+  mkdir -p "$jniDir"
+  cp -r "${PJSUA_SWIG_DIR}/java/output"/* "$jniDir"
+}
+
+cd ../
+projectDir=$PWD
+cd build-scripts/
+echo "Prepare working dir..."
+prepareWorkingDir
+echo "Install dependencies..."
+installDependencies
+echo "Set config state..."
+cd "$projectDir"
+setConfigSite
+echo "Building pjsip..."
+buildPjSip
+cd "$projectDir"
+echo "Finalising..."
+moveArtifacts
+
+echo "Finished: check the generated output in $WORKING_DIR/result"

--- a/build-scripts/config.conf
+++ b/build-scripts/config.conf
@@ -1,0 +1,31 @@
+###############################################################################
+###############################      SWIG       ###############################
+###############################################################################
+
+# SWIG Tool Version to download
+SWIG_VERSION=4.2.1
+
+# The URL from which to download SWIG sources tar
+SWIG_DOWNLOAD_URL="http://prdownloads.sourceforge.net/swig/swig-$SWIG_VERSION.tar.gz"
+
+
+###############################################################################
+##############################      OPENSSL       #############################
+###############################################################################
+
+# OpenSSL Version to download
+# we can not use newer version until https://github.com/openssl/openssl/issues/22414
+OPENSSL_VERSION=3.1.2
+
+# The URL from which to download OpenSSL sources tag
+OPENSSL_DOWNLOAD_URL="https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz"
+
+###############################################################################
+################################      OPUS      ###############################
+###############################################################################
+
+# OPUS Version to download
+OPUS_VERSION=1.3.1
+
+# The URL of the Opus repository
+OPUS_DOWNLOAD_URL="https://archive.mozilla.org/pub/opus/opus-$OPUS_VERSION.tar.gz"

--- a/build-scripts/openssl
+++ b/build-scripts/openssl
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+
+. config.conf
+
+function downloadOpenssl() {
+  workingDir="$1"
+  cd "$workingDir"
+  mkdir -p download
+  cd download
+  curl -L -# -o openssl.tar.gz "$OPENSSL_DOWNLOAD_URL" 2>&1
+  tar xzf openssl.tar.gz && rm -rf openssl.tar.gz
+}
+
+function buildOpenssl() {
+  workingDir="$1"
+  cd "$workingDir"
+  mkdir -p build
+  cd build
+  CFLAGS="-fPIC" ../download/openssl-"${OPENSSL_VERSION}"/Configure
+  make
+  make install
+  cd ../
+  mkdir -p libs/lib
+  cp build/libssl.a libs/lib
+  cp build/libcrypto.a libs/lib
+  cp -r build/include libs
+}

--- a/build-scripts/opus
+++ b/build-scripts/opus
@@ -1,0 +1,29 @@
+#!/bin/bash -e
+
+. config.conf
+
+function downloadOpus() {
+  workingDir="$1"
+  cd "$workingDir"
+  mkdir -p download
+  cd download
+  curl -L -# -o opus.tar.gz "$OPUS_DOWNLOAD_URL" 2>&1
+  tar xzf opus.tar.gz && rm -rf opus.tar.gz
+}
+
+function buildOpus() {
+  workingDir="$1"
+  cd "$workingDir"
+
+  mkdir -p build
+  cd build
+  CFLAGS="-fPIC" ../download/opus-"${OPUS_VERSION}"/configure
+  make
+  cd ../
+  mkdir -p libs/lib
+  cp build/.libs/libopus.a libs/lib
+  cp build/.libs/libopus.la libs/lib
+  cp build/.libs/libopus.lai libs/lib
+  mkdir -p libs/include/opus
+  cp -r "download/opus-${OPUS_VERSION}/include"/* libs/include/opus
+}

--- a/build-scripts/swig
+++ b/build-scripts/swig
@@ -1,0 +1,23 @@
+#!/bin/bash -e
+
+. config.conf
+
+function downloadSwig() {
+  workingDir="$1"
+  cd "$workingDir"
+  mkdir -p download
+  cd download
+  curl -L -# -o swig.tar.gz "$SWIG_DOWNLOAD_URL" 2>&1
+  tar xzf swig.tar.gz && rm -rf swig.tar.gz
+}
+
+function buildAndInstallSwig() {
+  workingDir="$1"
+  cd "$workingDir"
+
+  mkdir -p build
+  cd build
+   ../download/swig-"${SWIG_VERSION}"/configure
+  make
+  make install
+}


### PR DESCRIPTION
Build scripts for java-desktop: linux, mac arm64, mac x86.
Output binaries will allow create pjsip-client instance in own java process and interact with it using RMI. It will be used for integration tests for java/android platform. 