### PR TITLE
APPS-28234: add Opus ignore_remote_bitrate flag to override HPBX SDP cap

### DIFF
--- a/pjmedia/include/pjmedia-codec/opus.h
+++ b/pjmedia/include/pjmedia-codec/opus.h
@@ -104,6 +104,10 @@ typedef struct pjmedia_codec_opus_config
     unsigned   packet_loss; /**< Encoder's expected packet loss pct.    */
     unsigned   complexity;  /**< Encoder complexity, 0-10(10 is highest)*/
     pj_bool_t  cbr;         /**< Constant bit rate?                     */
+    pj_bool_t  ignore_remote_bitrate;
+                            /**< Ignore remote SDP maxaveragebitrate and
+                                 force the locally-configured bit_rate
+                                 (debug). Default PJ_FALSE.               */
 } pjmedia_codec_opus_config;
 
 /**

--- a/pjmedia/src/pjmedia-codec/opus.c
+++ b/pjmedia/src/pjmedia-codec/opus.c
@@ -169,6 +169,7 @@ static pjmedia_codec_opus_config opus_cfg =
     5,                                          /* Expected packet loss */
     PJMEDIA_CODEC_OPUS_DEFAULT_COMPLEXITY,      /* Complexity           */
     PJMEDIA_CODEC_OPUS_DEFAULT_CBR,             /* Constant bit rate    */
+    PJ_FALSE,                                   /* Ignore remote bitrate*/
 };
 
 
@@ -696,12 +697,19 @@ static pj_status_t  codec_open( pjmedia_codec *codec,
 
     /* Check max average bit rate */
     idx = find_fmtp(&attr->setting.enc_fmtp, &STR_MAX_BIT_RATE, PJ_FALSE);
-    if (idx >= 0) {
+    if (idx >= 0 && !opus_data->cfg.ignore_remote_bitrate) {
         unsigned rate;
         auto_bit_rate = PJ_FALSE;
         rate = (unsigned)pj_strtoul(&attr->setting.enc_fmtp.param[idx].val);
         if (rate < attr->info.avg_bps)
             attr->info.avg_bps = rate;
+    }
+
+    /* Ignore the remote SDP maxaveragebitrate and force the
+     * locally-configured bit_rate (e.g. above HPBX's cap). */
+    if (opus_data->cfg.ignore_remote_bitrate && opus_data->cfg.bit_rate) {
+        auto_bit_rate = PJ_FALSE;
+        attr->info.avg_bps = opus_data->cfg.bit_rate;
     }
 
     /* Check plc */
@@ -730,7 +738,7 @@ static pj_status_t  codec_open( pjmedia_codec *codec,
     
     /* Check max average bit rate */
     idx = find_fmtp(&attr->setting.dec_fmtp, &STR_MAX_BIT_RATE, PJ_FALSE);
-    if (idx >= 0) {
+    if (idx >= 0 && !opus_data->cfg.ignore_remote_bitrate) {
         unsigned rate;
         rate = (unsigned) pj_strtoul(&attr->setting.dec_fmtp.param[idx].val);
         if (rate < attr->info.avg_bps)
@@ -780,7 +788,7 @@ static pj_status_t  codec_open( pjmedia_codec *codec,
     PJ_LOG(4, (THIS_FILE, "Initialize Opus encoder, sample rate: %d, ch: %d, "
                           "avg bitrate: %d%s, vad: %d, plc: %d, pkt loss: %d, "
                           "complexity: %d, constant bit rate: %d, "
-                          "ptime: %d/%d",
+                          "ignore remote bitrate: %d, ptime: %d/%d",
                           opus_data->cfg.sample_rate,
                           opus_data->cfg.channel_cnt,
                           (auto_bit_rate? 0: attr->info.avg_bps),
@@ -790,6 +798,7 @@ static pj_status_t  codec_open( pjmedia_codec *codec,
                           opus_data->cfg.packet_loss,
                           opus_data->cfg.complexity,
                           opus_data->cfg.cbr?1:0,
+                          opus_data->cfg.ignore_remote_bitrate?1:0,
                           opus_data->enc_ptime,
                           opus_data->enc_ptime_denum));
 

--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -2610,6 +2610,9 @@ struct CodecOpusConfig
     unsigned   packet_loss; /**< Encoder's expected packet loss pct.    */
     unsigned   complexity;  /**< Encoder complexity, 0-10(10 is highest)*/
     bool       cbr;         /**< Constant bit rate?                     */
+    bool       ignore_remote_bitrate;
+                            /**< Ignore remote SDP maxaveragebitrate and
+                                 force the configured bit_rate (debug).   */
 
     pjmedia_codec_opus_config toPj() const;
     void fromPj(const pjmedia_codec_opus_config &config);

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -1979,6 +1979,7 @@ pjmedia_codec_opus_config CodecOpusConfig::toPj() const
     config.packet_loss = packet_loss;
     config.complexity = complexity;
     config.cbr = cbr;
+    config.ignore_remote_bitrate = ignore_remote_bitrate;
 
     return config;
 }
@@ -1993,6 +1994,7 @@ void CodecOpusConfig::fromPj(const pjmedia_codec_opus_config &config)
     packet_loss = config.packet_loss;
     complexity = config.complexity;
     cbr = PJ2BOOL(config.cbr);
+    ignore_remote_bitrate = PJ2BOOL(config.ignore_remote_bitrate);
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## What
Adds a `pj_bool_t ignore_remote_bitrate` flag to `pjmedia_codec_opus_config` (default `PJ_FALSE`). When set, `codec_open` stops clamping the Opus encoder down to the remote SDP `maxaveragebitrate` and instead forces the locally-configured `bit_rate`.

## Why (APPS-28108 / APPS-28234)
HPBX advertises `maxaveragebitrate=20000` in its SDP, which clamps the Android Opus encoder below what mobile↔mobile negotiates. This flag lets debug/autotest builds ignore that cap and transmit at a locally-chosen bitrate (e.g. 24000) to test whether a higher bitrate improves PSTN/HPBX call quality.

## Changes
- `pjmedia-codec/opus.h`: new struct field + default in the `opus_cfg` initializer.
- `pjmedia-codec/opus.c`: guard both fmtp `maxaveragebitrate` clamps with `!ignore_remote_bitrate`; when the flag + a configured `bit_rate` are set, force `attr->info.avg_bps = cfg.bit_rate`; surface the flag in the encoder-init log line.
- `pjsua2/media.hpp` + `media.cpp`: plumb the field through the `CodecOpusConfig` binding (`toPj`/`fromPj`); SWIG regenerates the Java accessor.

## Safety
Default-off (`PJ_FALSE`). With the flag unset, behavior is identical to before — only the debug override path uses it.