### PR TITLE
APPS-28234: copy ignore_remote_bitrate into global opus_cfg in set_default_param

### DIFF
--- a/pjmedia/src/pjmedia-codec/opus.c
+++ b/pjmedia/src/pjmedia-codec/opus.c
@@ -462,7 +462,8 @@ pjmedia_codec_opus_set_default_param(const pjmedia_codec_opus_config *cfg,
     opus_cfg.complexity = cfg->complexity;
 
     opus_cfg.cbr = cfg->cbr;
-    
+    opus_cfg.ignore_remote_bitrate = cfg->ignore_remote_bitrate;
+
     generate_fmtp(param);
 
     status = pjmedia_codec_mgr_set_default_param(codec_mgr, info[0], param);


### PR DESCRIPTION
The flag was plumbed through CodecOpusConfig::toPj and read in codec_open, but pjmedia_codec_opus_set_default_param copied every other field into the global opus_cfg except ignore_remote_bitrate, so it never reached the per-call config (memcpy in codec_alloc) and the remote maxaveragebitrate clamp was always applied. Add the missing field copy next to opus_cfg.cbr.